### PR TITLE
Add main entry to Bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,5 +22,8 @@
   "devDependencies": {
     "purescript-assert": "^0.1.0",
     "purescript-console": "^0.1.0"
-  }
+  },
+  "main": [
+    "src/Global.purs"
+  ]
 }


### PR DESCRIPTION
This fixes this warning when installing purescript-globals through Bower:

    bower invalid-meta  purescript-globals is missing "main" entry in bower.json