### PR TITLE
toFixed, toExponential, toPrecision Number methods implemented

### DIFF
--- a/src/Global/Unsafe.js
+++ b/src/Global/Unsafe.js
@@ -7,20 +7,20 @@ exports.unsafeStringify = function (x) {
   return JSON.stringify(x);
 };
 
-exports.unsafeToFixed = function (n) {
-  return function (digits) {
+exports.unsafeToFixed = function (digits) {
+  return function (n) {
     return n.toFixed(digits);
   };
 };
 
-exports.unsafeToExponential = function (n) {
-  return function (digits) {
+exports.unsafeToExponential = function (digits) {
+  return function (n) {
     return n.toExponential(digits);
   };
 };
 
-exports.unsafeToPrecision  = function (n) {
-  return function (digits) {
+exports.unsafeToPrecision  = function (digits) {
+  return function (n) {
     return n.toPrecision(digits);
   };
 };

--- a/src/Global/Unsafe.js
+++ b/src/Global/Unsafe.js
@@ -10,18 +10,18 @@ exports.unsafeStringify = function (x) {
 exports.unsafeToFixed = function (n) {
   return function (digits) {
     return n.toFixed(digits);
-  }
+  };
 };
 
 exports.unsafeToExponential = function (n) {
   return function (digits) {
     return n.toExponential(digits);
-  }
+  };
 };
 
 exports.unsafeToPrecision  = function (n) {
   return function (digits) {
     return n.toPrecision(digits);
-  }
+  };
 };
 

--- a/src/Global/Unsafe.js
+++ b/src/Global/Unsafe.js
@@ -6,3 +6,22 @@
 exports.unsafeStringify = function (x) {
   return JSON.stringify(x);
 };
+
+exports.unsafeToFixed = function (n) {
+  return function (digits) {
+    return n.toFixed(digits);
+  }
+};
+
+exports.unsafeToExponential = function (n) {
+  return function (digits) {
+    return n.toExponential(digits);
+  }
+};
+
+exports.unsafeToPrecision  = function (n) {
+  return function (digits) {
+    return n.toPrecision(digits);
+  }
+};
+

--- a/src/Global/Unsafe.purs
+++ b/src/Global/Unsafe.purs
@@ -7,16 +7,16 @@ foreign import unsafeStringify :: forall a. a -> String
 -- | Formats Number as a String with limited number of digits after the dot
 -- | May throw RangeError if the number of digits is not within the allowed range
 -- | (standard precision range is 0 to 20, but implementations may change it)
-foreign import unsafeToFixed :: Number -> Int -> String
+foreign import unsafeToFixed :: Int -> Number -> String
 
 -- | Formats Number as String in exponential notation limiting number of digits
 -- | after the decimal dot. 
 -- | May throw RangeError if the number of digits is not within the allowed range
 -- | (standard precision range is 0 to 20, but implementations may change it)
-foreign import unsafeToExponential :: Number -> Int -> String
+foreign import unsafeToExponential :: Int -> Number -> String
 
 -- | Formats Number as String in fixed-point or exponential notation rounded 
 -- | to specified number of significant digits.
 -- | May throw RangeError if the number of digits is not within the allowed range
 -- | (standard precision range is 0 to 100, but implementations may change it)
-foreign import unsafeToPrecision :: Number -> Int -> String
+foreign import unsafeToPrecision :: Int -> Number -> String

--- a/src/Global/Unsafe.purs
+++ b/src/Global/Unsafe.purs
@@ -3,3 +3,20 @@ module Global.Unsafe where
 -- | Uses the global JSON object to turn anything into a string. Careful! Trying
 -- | to serialize functions returns undefined
 foreign import unsafeStringify :: forall a. a -> String
+
+-- | Formats Number as a String with limited number of digits after the dot
+-- | May throw RangeError if the number of digits is not within the allowed range
+-- | (standard precision range is 0 to 20, but implementations may change it)
+foreign import unsafeToFixed :: Number -> Int -> String
+
+-- | Formats Number as String in exponential notation limiting number of digits
+-- | after the decimal dot. 
+-- | May throw RangeError if the number of digits is not within the allowed range
+-- | (standard precision range is 0 to 20, but implementations may change it)
+foreign import unsafeToExponential :: Number -> Int -> String
+
+-- | Formats Number as String in fixed-point or exponential notation rounded 
+-- | to specified number of significant digits.
+-- | May throw RangeError if the number of digits is not within the allowed range
+-- | (standard precision range is 0 to 100, but implementations may change it)
+foreign import unsafeToPrecision :: Number -> Int -> String

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,16 +1,18 @@
 module Test.Main where
 
-import Prelude (Unit, (==), ($), bind, not, negate, (<), (>), (/=))
+import Prelude
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
-import Global
+import Global (readFloat, readInt, isFinite, infinity, nan, isNaN)
+import Global.Unsafe (unsafeToPrecision, unsafeToExponential, unsafeToFixed)
 
 import Test.Assert (ASSERT, assert)
 
 main :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
 main = do
+  let num = 12345.6789
 
   log "nan /= nan"
   assert $ nan /= nan
@@ -41,3 +43,21 @@ main = do
 
   log "readFloat \"3.5\" == 3.5"
   assert $ readFloat "3.5" == 3.5
+
+  -- note the rounding
+  log $ "unsafeToFixed " <> (show num) <> " 1 == \"12345.7\""
+  assert $ unsafeToFixed num 1 == "12345.7"
+
+  -- padded with zeros
+  log $ "unsafeToFixed " <> (show num) <> " 6 == \"12345.678900\""
+  assert $ unsafeToFixed num 6 == "12345.678900"
+
+  log $ "unsafeToExponential " <> (show num) <> " 4 == \"1.2346e+4\""
+  assert $ unsafeToExponential num 4 == "1.2346e+4"
+
+  log $ "unsafeToPrecision " <> (show num) <> " 3 == \"1.23e+4\""
+  assert $ unsafeToPrecision num 3 == "1.23e+4"
+
+  log $ "unsafeToPrecision " <> (show num) <> " 6 == \"12345.7\""
+  assert $ unsafeToPrecision num 6 == "12345.7"
+

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -45,19 +45,19 @@ main = do
   assert $ readFloat "3.5" == 3.5
 
   -- note the rounding
-  log $ "unsafeToFixed " <> (show num) <> " 1 == \"12345.7\""
-  assert $ unsafeToFixed num 1 == "12345.7"
+  log $ "unsafeToFixed 1" <> (show num) <> " == \"12345.7\""
+  assert $ unsafeToFixed 1 num == "12345.7"
 
   -- padded with zeros
-  log $ "unsafeToFixed " <> (show num) <> " 6 == \"12345.678900\""
-  assert $ unsafeToFixed num 6 == "12345.678900"
+  log $ "unsafeToFixed 6" <> (show num) <> " == \"12345.678900\""
+  assert $ unsafeToFixed 6 num == "12345.678900"
 
-  log $ "unsafeToExponential " <> (show num) <> " 4 == \"1.2346e+4\""
-  assert $ unsafeToExponential num 4 == "1.2346e+4"
+  log $ "unsafeToExponential 4" <> (show num) <> " == \"1.2346e+4\""
+  assert $ unsafeToExponential 4 num == "1.2346e+4"
 
-  log $ "unsafeToPrecision " <> (show num) <> " 3 == \"1.23e+4\""
-  assert $ unsafeToPrecision num 3 == "1.23e+4"
+  log $ "unsafeToPrecision 3" <> (show num) <> " == \"1.23e+4\""
+  assert $ unsafeToPrecision 3 num == "1.23e+4"
 
-  log $ "unsafeToPrecision " <> (show num) <> " 6 == \"12345.7\""
-  assert $ unsafeToPrecision num 6 == "12345.7"
+  log $ "unsafeToPrecision 6" <> (show num) <> " == \"12345.7\""
+  assert $ unsafeToPrecision 6 num == "12345.7"
 


### PR DESCRIPTION

These functions may throw if they don't like the integer parameter, specifying the number of digits and the exact supported range is implementation specific. Thus is put these in Globals.Unsafe
